### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/bundles/extensions/event/src/test/java/org/apache/sling/event/it/AbstractJobHandlingTest.java
+++ b/bundles/extensions/event/src/test/java/org/apache/sling/event/it/AbstractJobHandlingTest.java
@@ -110,7 +110,7 @@ public abstract class AbstractJobHandlingTest {
 
                 mavenBundle("commons-io", "commons-io", "1.4"),
                 mavenBundle("commons-fileupload", "commons-fileupload", "1.3.1"),
-                mavenBundle("commons-collections", "commons-collections", "3.2.1"),
+                mavenBundle("commons-collections", "commons-collections", "3.2.2"),
                 mavenBundle("commons-codec", "commons-codec", "1.9"),
                 mavenBundle("commons-lang", "commons-lang", "2.6"),
                 mavenBundle("commons-pool", "commons-pool", "1.6"),

--- a/bundles/extensions/healthcheck/it/src/test/java/org/apache/sling/hc/it/core/U.java
+++ b/bundles/extensions/healthcheck/it/src/test/java/org/apache/sling/hc/it/core/U.java
@@ -94,7 +94,7 @@ public class U {
                     mavenBundle("org.apache.sling", "org.apache.sling.scripting.api", "2.1.0"),
                     mavenBundle("org.apache.sling", "org.apache.sling.commons.threads", "3.1.0"),
                     mavenBundle("org.apache.sling", "org.apache.sling.commons.scheduler", "2.4.2"),
-                    mavenBundle("commons-collections", "commons-collections", "3.2.1"),
+                    mavenBundle("commons-collections", "commons-collections", "3.2.2"),
                     mavenBundle("commons-io", "commons-io", "1.4"),
                     mavenBundle("commons-fileupload", "commons-fileupload", "1.2.2"),
                     mavenBundle("commons-lang", "commons-lang", "2.5"),

--- a/bundles/extensions/validation/api/pom.xml
+++ b/bundles/extensions/validation/api/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bundles/extensions/validation/core/pom.xml
+++ b/bundles/extensions/validation/core/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/jcr/it-jackrabbit-oak/src/test/java/org/apache/sling/jcr/repository/it/CommonTests.java
+++ b/bundles/jcr/it-jackrabbit-oak/src/test/java/org/apache/sling/jcr/repository/it/CommonTests.java
@@ -174,7 +174,7 @@ public abstract class CommonTests {
 
         opt.add(mavenBundle("commons-io", "commons-io", "2.4"));
         opt.add(mavenBundle("commons-fileupload", "commons-fileupload", "1.3.1"));
-        opt.add(mavenBundle("commons-collections", "commons-collections", "3.2.1"));
+        opt.add(mavenBundle("commons-collections", "commons-collections", "3.2.2"));
         opt.add(mavenBundle("commons-codec", "commons-codec", "1.9"));
         opt.add(mavenBundle("commons-lang", "commons-lang", "2.6"));
         opt.add(mavenBundle("commons-pool", "commons-pool", "1.6"));

--- a/bundles/jcr/resource/pom.xml
+++ b/bundles/jcr/resource/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/resourceaccesssecurity/core/pom.xml
+++ b/bundles/resourceaccesssecurity/core/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
            <groupId>commons-collections</groupId>
            <artifactId>commons-collections</artifactId>
-           <version>3.2.1</version>
+           <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/resourceresolver/pom.xml
+++ b/bundles/resourceresolver/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
            <groupId>commons-collections</groupId>
            <artifactId>commons-collections</artifactId>
-           <version>3.2.1</version>
+           <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundles/scripting/javascript/pom.xml
+++ b/bundles/scripting/javascript/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
         <!-- Testing -->

--- a/contrib/crankstart/launcher/src/test/resources/provisioning-model/start-level-99.txt
+++ b/contrib/crankstart/launcher/src/test/resources/provisioning-model/start-level-99.txt
@@ -21,4 +21,4 @@
 [feature name=startlevel99]
 
 [artifacts startLevel=99]
-  commons-collections/commons-collections/3.2.1
+  commons-collections/commons-collections/3.2.2

--- a/contrib/extensions/cache/container-test/src/main/java/org/apache/sling/test/AbstractOSGiRunner.java
+++ b/contrib/extensions/cache/container-test/src/main/java/org/apache/sling/test/AbstractOSGiRunner.java
@@ -113,7 +113,7 @@ public  abstract class AbstractOSGiRunner {
 						// bound to need servlet api
 						mavenBundle("org.apache.felix", "javax.servlet","1.0.0"),
 						// standard items.
-						mavenBundle("commons-collections", "commons-collections", "3.2.1"), // 3.2.1 is a bundle, 3.2 is not
+						mavenBundle("commons-collections", "commons-collections", "3.2.2"), // 3.2.1 is a bundle, 3.2 is not
 						mavenBundle("commons-io", "commons-io", "1.4"),
 						// export ourselves
 						wrappedBundle(mavenBundle("org.apache.sling","org.apache.sling.commons.cache.container-test")).exports(AbstractOSGiRunner.class.getPackage().getName()),

--- a/contrib/launchpad/karaf/org.apache.sling.launchpad.karaf-features/src/main/feature/feature.xml
+++ b/contrib/launchpad/karaf/org.apache.sling.launchpad.karaf-features/src/main/feature/feature.xml
@@ -50,7 +50,7 @@
     <feature version="${project.version}">sling-commons-threads</feature>
     <bundle dependency="true">mvn:javax.jcr/jcr/2.0</bundle>
     <bundle dependency="true">mvn:commons-codec/commons-codec/1.9</bundle>
-    <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.1</bundle>
+    <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.2</bundle>
     <bundle dependency="true">mvn:commons-fileupload/commons-fileupload/1.3.1</bundle>
     <bundle dependency="true">mvn:commons-io/commons-io/2.4</bundle>
     <bundle dependency="true">mvn:commons-lang/commons-lang/2.6</bundle>
@@ -345,7 +345,7 @@
     <bundle dependency="true">mvn:javax.jcr/jcr/2.0</bundle>
     <!-- TODO... -->
     <bundle dependency="true">mvn:commons-codec/commons-codec/1.9</bundle>
-    <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.1</bundle>
+    <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.2</bundle>
     <bundle dependency="true">mvn:commons-fileupload/commons-fileupload/1.3.1</bundle>
     <bundle dependency="true">mvn:commons-io/commons-io/2.4</bundle>
     <bundle dependency="true">mvn:commons-lang/commons-lang/2.6</bundle>

--- a/contrib/sling-s3/crank.d/60-provisioning-sling.txt
+++ b/contrib/sling-s3/crank.d/60-provisioning-sling.txt
@@ -1,6 +1,6 @@
 defaults crankstart.bundle.start.level 1
 bundle mvn:commons-fileupload/commons-fileupload/1.3.1
-bundle mvn:commons-collections/commons-collections/3.2.1
+bundle mvn:commons-collections/commons-collections/3.2.2
 bundle mvn:commons-codec/commons-codec/1.9
 bundle mvn:commons-lang/commons-lang/2.6
 bundle mvn:org.apache.commons/commons-math/2.2

--- a/launchpad/builder/src/main/provisioning/sling.txt
+++ b/launchpad/builder/src/main/provisioning/sling.txt
@@ -21,7 +21,7 @@
 
 [artifacts]
     commons-fileupload/commons-fileupload/1.3.1
-    commons-collections/commons-collections/3.2.1
+    commons-collections/commons-collections/3.2.2
     commons-codec/commons-codec/1.9
     commons-lang/commons-lang/2.6
     org.apache.commons/commons-math/2.2

--- a/samples/fling/pom.xml
+++ b/samples/fling/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
       <scope>provided</scope>
     </dependency>
     <!-- Apache Sling -->

--- a/testing/mocks/sling-mock/pom.xml
+++ b/testing/mocks/sling-mock/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/tooling/maven/maven-launchpad-plugin/src/test/resources/test-bundle-list.xml
+++ b/tooling/maven/maven-launchpad-plugin/src/test/resources/test-bundle-list.xml
@@ -40,7 +40,7 @@
         <bundle>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </bundle>
         <bundle>
             <groupId>org.apache.sling</groupId>

--- a/tooling/support/provisioning-model/src/test/java/org/apache/sling/provisioning/model/U.java
+++ b/tooling/support/provisioning-model/src/test/java/org/apache/sling/provisioning/model/U.java
@@ -96,7 +96,7 @@ public class U {
 
         {
             final ArtifactGroup g = getGroup(m, "example", DEFAULT_RUN_MODE, DEFAULT_START_LEVEL);
-            U.assertArtifact(g, "mvn:commons-collections/commons-collections/3.2.1/jar");
+            U.assertArtifact(g, "mvn:commons-collections/commons-collections/3.2.2/jar");
             U.assertArtifact(g, "mvn:org.example/jar-is-default/1.2/jar");
         }
 

--- a/tooling/support/provisioning-model/src/test/resources/example.txt
+++ b/tooling/support/provisioning-model/src/test/resources/example.txt
@@ -38,7 +38,7 @@
 [artifacts]
     commons-io/commons-io/1.4/jar
     commons-fileupload/commons-fileupload/1.3.1/jar
-    commons-collections/commons-collections/3.2.1/jar
+    commons-collections/commons-collections/3.2.2/jar
     commons-codec/commons-codec/1.9/jar
     commons-lang/commons-lang/2.6/jar
     org.apache.commons/commons-math/2.2/jar

--- a/tooling/support/provisioning-model/src/test/resources/main.txt
+++ b/tooling/support/provisioning-model/src/test/resources/main.txt
@@ -24,7 +24,7 @@
 [artifacts]
     commons-io/commons-io/1.4/jar
     commons-fileupload/commons-fileupload/1.3.1/jar
-    commons-collections/commons-collections/3.2.1/jar
+    commons-collections/commons-collections/3.2.2/jar
     commons-codec/commons-codec/1.9/jar
     commons-lang/commons-lang/2.6/jar
     org.apache.commons/commons-math/2.2/jar


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/